### PR TITLE
Expand tool coverage in parser

### DIFF
--- a/src/tools/parser.rs
+++ b/src/tools/parser.rs
@@ -1,5 +1,7 @@
 use super::core::{
-    AvailableTool, HttpMethod, ModelParameter,
+    ApiAuth, AvailableTool, CargoOperation, DatabaseType, DockerResourceType, EditOperation,
+    ExportFormat, GitBranchOperation, HttpMethod, ModelParameter, NpmOperation, PipOperation,
+    RestOperation, TextOperation,
 };
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
@@ -98,6 +100,10 @@ AVAILABLE TOOLS AND THEIR USAGE PATTERNS:
   Parameters: path (string, exact filename), duration_seconds (optional number, convert minutes to seconds)
   IMPORTANT: For "watch the X" format, extract X as the path, not "the"
 
+- CreateProject: Generate a new project
+  Examples: "create python project myapp", "make javascript project"
+  Parameters: name (string), project_type (string), path (optional string)
+
 ## Git Operations
 - GitStatus: Check repository status
   Examples: "git status", "check git", "repo status", "show changes"
@@ -166,6 +172,36 @@ AVAILABLE TOOLS AND THEIR USAGE PATTERNS:
   Examples: "npm install", "npm run dev", "install express", "run tests"
   Parameters: operation (enum), package (optional string), dev (boolean)
 
+- PipOperation: Python operations
+  Examples: "pip install requests", "pip list", "pip uninstall package"
+  Parameters: operation (enum), package (optional string), requirements_file (optional string)
+
+## Docker Operations
+- DockerList: List Docker resources
+  Examples: "list containers", "show docker images"
+  Parameters: resource_type (enum)
+
+- DockerRun: Run a container
+  Examples: "run nginx", "start postgres with ports"
+  Parameters: image (string), command (optional string), ports (optional array), volumes (optional array), environment (optional object)
+
+- DockerStop: Stop a container
+  Examples: "stop container web", "docker stop myapp"
+  Parameters: container (string)
+
+- DockerLogs: Show container logs
+  Examples: "docker logs web", "show logs for api -f"
+  Parameters: container (string), follow (boolean), tail (optional number)
+
+## Database Operations
+- SqlQuery: Query databases
+  Examples: "run SQL select", "query postgres db"
+  Parameters: connection_string (string), query (string), database_type (enum)
+
+- SqliteQuery: Query SQLite file
+  Examples: "query data.db", "sqlite select"
+  Parameters: database_path (string), query (string)
+
 ## Web & API
 - WebSearch: Search internet
   Examples: "search rust tutorials", "google python guides", "find documentation"
@@ -179,10 +215,30 @@ AVAILABLE TOOLS AND THEIR USAGE PATTERNS:
   Examples: "GET api.example.com", "POST to webhook", "HTTP request to server"
   Parameters: method (enum), url (string), headers (optional object), body (optional string)
 
+- RestApiCall: High level REST API operation
+  Examples: "create user via /api", "delete /api/item/1"
+  Parameters: endpoint (string), operation (enum), data (optional object), auth (optional object)
+
+- GraphQLQuery: Execute GraphQL operations
+  Examples: "query GraphQL endpoint", "graphql mutation"
+  Parameters: endpoint (string), query (string), variables (optional object), auth (optional object)
+
 ## Text Processing
 - JsonFormat: Format JSON
   Examples: "format json", "pretty print json", "beautify json data"
   Parameters: input (string)
+
+- JsonQuery: Query JSON data
+  Examples: "get .users[0] from json", "json query"
+  Parameters: input (string), query (string)
+
+- CsvParse: Parse CSV text
+  Examples: "parse csv", "csv data with ; delimiter"
+  Parameters: input (string), delimiter (optional char)
+
+- TextTransform: Text manipulation
+  Examples: "uppercase this text", "replace foo with bar"
+  Parameters: input (string), operation (enum)
 
 - RegexMatch: Pattern matching
   Examples: "find emails in text", "match phone numbers", "extract urls"
@@ -192,6 +248,35 @@ AVAILABLE TOOLS AND THEIR USAGE PATTERNS:
 - ClearHistory: Clear conversation
   Examples: "clear history", "clear conversation", "reset chat", "new session"
   Parameters: none
+
+- SetConfig: Update configuration value
+  Examples: "set api_key", "configure timeout"
+  Parameters: key (string), value (any)
+
+- GetConfig: View configuration
+  Examples: "get config", "show setting api_key"
+  Parameters: key (optional string)
+
+- ExportConversation: Save chat history
+  Examples: "export chat to file", "save conversation as json"
+  Parameters: format (enum), path (string)
+
+- ImportConversation: Load chat history
+  Examples: "import conversation from file"
+  Parameters: path (string)
+
+## Advanced Operations
+- ScheduleTask: Schedule recurring command
+  Examples: "schedule task \"backup.sh\" daily", "run cleanup every hour"
+  Parameters: command (string), schedule (string), name (optional string)
+
+- ListScheduledTasks: Show scheduled tasks
+  Examples: "list scheduled tasks"
+  Parameters: none
+
+- CancelScheduledTask: Cancel scheduled command
+  Examples: "cancel task backup", "remove scheduled cleanup"
+  Parameters: name (string)
 
 PARSING RULES:
 1. Understand user intent, not just keywords
@@ -254,12 +339,14 @@ Analyze the request and respond with JSON only:"#,
             match tool_req.tool_type.as_str() {
                 // Existing tools
                 "FileRead" => {
-                    let path = tool_req.parameters.get("path")
+                    let path = tool_req
+                        .parameters
+                        .get("path")
                         .or_else(|| tool_req.parameters.get("filename"))
                         .or_else(|| tool_req.parameters.get("file"))
                         .or_else(|| tool_req.parameters.get("filepath"))
                         .and_then(|v| v.as_str());
-                    
+
                     if let Some(path) = path {
                         tools.push(AvailableTool::FileRead {
                             path: path.to_string(),
@@ -267,12 +354,14 @@ Analyze the request and respond with JSON only:"#,
                     }
                 }
                 "FileWrite" => {
-                    let path = tool_req.parameters.get("path")
+                    let path = tool_req
+                        .parameters
+                        .get("path")
                         .or_else(|| tool_req.parameters.get("filename"))
                         .or_else(|| tool_req.parameters.get("file"))
                         .or_else(|| tool_req.parameters.get("filepath"))
                         .and_then(|v| v.as_str());
-                    
+
                     if let Some(path) = path {
                         let content = tool_req
                             .parameters
@@ -286,6 +375,25 @@ Analyze the request and respond with JSON only:"#,
                             path: path.to_string(),
                             content,
                         });
+                    }
+                }
+                "FileEdit" => {
+                    let path = tool_req
+                        .parameters
+                        .get("path")
+                        .or_else(|| tool_req.parameters.get("filename"))
+                        .or_else(|| tool_req.parameters.get("file"))
+                        .or_else(|| tool_req.parameters.get("filepath"))
+                        .and_then(|v| v.as_str());
+
+                    if let (Some(path), Some(op_val)) = (path, tool_req.parameters.get("operation"))
+                    {
+                        if let Some(operation) = Self::parse_edit_operation(op_val) {
+                            tools.push(AvailableTool::FileEdit {
+                                path: path.to_string(),
+                                operation,
+                            });
+                        }
                     }
                 }
                 "WebSearch" => {
@@ -448,7 +556,7 @@ Analyze the request and respond with JSON only:"#,
                         .or_else(|| tool_req.parameters.get("model"))
                         .or_else(|| tool_req.parameters.get("name"))
                         .and_then(|v| v.as_str());
-                    
+
                     if let Some(model_name) = model_name {
                         tools.push(AvailableTool::SwitchModel {
                             model_name: model_name.to_string(),
@@ -483,12 +591,14 @@ Analyze the request and respond with JSON only:"#,
                 // File watching
                 "FileWatch" => {
                     // Try multiple parameter names for flexibility
-                    let path = tool_req.parameters.get("path")
+                    let path = tool_req
+                        .parameters
+                        .get("path")
                         .or_else(|| tool_req.parameters.get("filename"))
                         .or_else(|| tool_req.parameters.get("file"))
                         .or_else(|| tool_req.parameters.get("filepath"))
                         .and_then(|v| v.as_str());
-                    
+
                     if let Some(path) = path {
                         let duration_seconds = tool_req
                             .parameters
@@ -501,16 +611,21 @@ Analyze the request and respond with JSON only:"#,
                                 if let Some(s) = v.as_str() {
                                     let s = s.trim().to_lowercase();
                                     if s.ends_with(" minutes") || s.ends_with(" minute") {
-                                        s.split_whitespace().next()
+                                        s.split_whitespace()
+                                            .next()
                                             .and_then(|num| num.parse::<u64>().ok())
                                             .map(|n| n * 60)
                                     } else if s.ends_with(" seconds") || s.ends_with(" second") {
-                                        s.split_whitespace().next()
+                                        s.split_whitespace()
+                                            .next()
                                             .and_then(|num| num.parse::<u64>().ok())
                                     } else if s.ends_with('s') {
                                         s.trim_end_matches('s').parse::<u64>().ok()
                                     } else if s.ends_with("min") {
-                                        s.trim_end_matches("min").parse::<u64>().ok().map(|n| n * 60)
+                                        s.trim_end_matches("min")
+                                            .parse::<u64>()
+                                            .ok()
+                                            .map(|n| n * 60)
                                     } else {
                                         s.parse::<u64>().ok()
                                     }
@@ -521,6 +636,652 @@ Analyze the request and respond with JSON only:"#,
                         tools.push(AvailableTool::FileWatch {
                             path: path.to_string(),
                             duration_seconds,
+                        });
+                    }
+                }
+
+                "FileSearch" => {
+                    let pattern = tool_req.parameters.get("pattern").and_then(|v| v.as_str());
+                    let directory = tool_req
+                        .parameters
+                        .get("directory")
+                        .and_then(|v| v.as_str());
+                    if let Some(pattern) = pattern {
+                        tools.push(AvailableTool::FileSearch {
+                            pattern: pattern.to_string(),
+                            directory: directory.map(|d| d.to_string()),
+                        });
+                    }
+                }
+                "ContentSearch" => {
+                    let pattern = tool_req.parameters.get("pattern").and_then(|v| v.as_str());
+                    let directory = tool_req
+                        .parameters
+                        .get("directory")
+                        .and_then(|v| v.as_str());
+                    if let Some(pattern) = pattern {
+                        tools.push(AvailableTool::ContentSearch {
+                            pattern: pattern.to_string(),
+                            directory: directory.map(|d| d.to_string()),
+                        });
+                    }
+                }
+                "ListDirectory" => {
+                    let path = tool_req
+                        .parameters
+                        .get("path")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or(".");
+                    tools.push(AvailableTool::ListDirectory {
+                        path: path.to_string(),
+                    });
+                }
+                "CreateProject" => {
+                    if let Some(name) = tool_req.parameters.get("name").and_then(|v| v.as_str()) {
+                        let project_type = tool_req
+                            .parameters
+                            .get("project_type")
+                            .or_else(|| tool_req.parameters.get("type"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("generic");
+                        let path = tool_req
+                            .parameters
+                            .get("path")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string());
+                        tools.push(AvailableTool::CreateProject {
+                            name: name.to_string(),
+                            project_type: project_type.to_string(),
+                            path,
+                        });
+                    }
+                }
+                "ExecuteCommand" => {
+                    if let Some(command) =
+                        tool_req.parameters.get("command").and_then(|v| v.as_str())
+                    {
+                        tools.push(AvailableTool::ExecuteCommand {
+                            command: command.to_string(),
+                        });
+                    }
+                }
+
+                "WebScrape" => {
+                    if let Some(url) = tool_req.parameters.get("url").and_then(|v| v.as_str()) {
+                        tools.push(AvailableTool::WebScrape {
+                            url: url.to_string(),
+                        });
+                    }
+                }
+
+                "GitPush" => {
+                    let remote = tool_req
+                        .parameters
+                        .get("remote")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    let branch = tool_req
+                        .parameters
+                        .get("branch")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    let repository_path = tool_req
+                        .parameters
+                        .get("repository_path")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    tools.push(AvailableTool::GitPush {
+                        remote,
+                        branch,
+                        repository_path,
+                    });
+                }
+                "GitPull" => {
+                    let remote = tool_req
+                        .parameters
+                        .get("remote")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    let branch = tool_req
+                        .parameters
+                        .get("branch")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    let repository_path = tool_req
+                        .parameters
+                        .get("repository_path")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    tools.push(AvailableTool::GitPull {
+                        remote,
+                        branch,
+                        repository_path,
+                    });
+                }
+                "GitBranch" => {
+                    if let Some(op) = tool_req
+                        .parameters
+                        .get("operation")
+                        .and_then(|v| v.as_str())
+                    {
+                        let operation = match op.to_lowercase().as_str() {
+                            "list" => GitBranchOperation::List,
+                            "create" => {
+                                if let Some(name) =
+                                    tool_req.parameters.get("name").and_then(|v| v.as_str())
+                                {
+                                    GitBranchOperation::Create {
+                                        name: name.to_string(),
+                                    }
+                                } else {
+                                    GitBranchOperation::List
+                                }
+                            }
+                            "switch" => {
+                                if let Some(name) =
+                                    tool_req.parameters.get("name").and_then(|v| v.as_str())
+                                {
+                                    GitBranchOperation::Switch {
+                                        name: name.to_string(),
+                                    }
+                                } else {
+                                    GitBranchOperation::List
+                                }
+                            }
+                            "delete" => {
+                                if let Some(name) =
+                                    tool_req.parameters.get("name").and_then(|v| v.as_str())
+                                {
+                                    GitBranchOperation::Delete {
+                                        name: name.to_string(),
+                                    }
+                                } else {
+                                    GitBranchOperation::List
+                                }
+                            }
+                            "merge" => {
+                                if let Some(from) =
+                                    tool_req.parameters.get("from").and_then(|v| v.as_str())
+                                {
+                                    GitBranchOperation::Merge {
+                                        from: from.to_string(),
+                                    }
+                                } else {
+                                    GitBranchOperation::List
+                                }
+                            }
+                            _ => GitBranchOperation::List,
+                        };
+                        let repository_path = tool_req
+                            .parameters
+                            .get("repository_path")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string());
+                        tools.push(AvailableTool::GitBranch {
+                            operation,
+                            repository_path,
+                        });
+                    }
+                }
+                "GitLog" => {
+                    let count = tool_req
+                        .parameters
+                        .get("count")
+                        .and_then(|v| v.as_u64())
+                        .map(|n| n as u32);
+                    let oneline = tool_req
+                        .parameters
+                        .get("oneline")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    let repository_path = tool_req
+                        .parameters
+                        .get("repository_path")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    tools.push(AvailableTool::GitLog {
+                        count,
+                        oneline,
+                        repository_path,
+                    });
+                }
+                "GitDiff" => {
+                    let file = tool_req
+                        .parameters
+                        .get("file")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    let cached = tool_req
+                        .parameters
+                        .get("cached")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    let repository_path = tool_req
+                        .parameters
+                        .get("repository_path")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    tools.push(AvailableTool::GitDiff {
+                        file,
+                        cached,
+                        repository_path,
+                    });
+                }
+
+                "RestApiCall" => {
+                    if let Some(endpoint) =
+                        tool_req.parameters.get("endpoint").and_then(|v| v.as_str())
+                    {
+                        let operation = tool_req
+                            .parameters
+                            .get("operation")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("get");
+                        let data = tool_req.parameters.get("data").cloned();
+                        let auth = tool_req
+                            .parameters
+                            .get("auth")
+                            .cloned()
+                            .and_then(|v| Self::parse_api_auth(&v));
+                        let op_enum = match operation.to_lowercase().as_str() {
+                            "create" => RestOperation::Create {
+                                data: data.clone().unwrap_or(serde_json::Value::Null),
+                            },
+                            "update" => {
+                                if let Some(id) =
+                                    tool_req.parameters.get("id").and_then(|v| v.as_str())
+                                {
+                                    RestOperation::Update {
+                                        id: id.to_string(),
+                                        data: data.clone().unwrap_or(serde_json::Value::Null),
+                                    }
+                                } else {
+                                    RestOperation::Get
+                                }
+                            }
+                            "delete" => {
+                                if let Some(id) =
+                                    tool_req.parameters.get("id").and_then(|v| v.as_str())
+                                {
+                                    RestOperation::Delete { id: id.to_string() }
+                                } else {
+                                    RestOperation::Get
+                                }
+                            }
+                            _ => RestOperation::Get,
+                        };
+                        tools.push(AvailableTool::RestApiCall {
+                            endpoint: endpoint.to_string(),
+                            operation: op_enum,
+                            data,
+                            auth,
+                        });
+                    }
+                }
+                "GraphQLQuery" => {
+                    if let Some(endpoint) =
+                        tool_req.parameters.get("endpoint").and_then(|v| v.as_str())
+                    {
+                        if let Some(query) =
+                            tool_req.parameters.get("query").and_then(|v| v.as_str())
+                        {
+                            let variables = tool_req.parameters.get("variables").cloned();
+                            let auth = tool_req
+                                .parameters
+                                .get("auth")
+                                .cloned()
+                                .and_then(|v| Self::parse_api_auth(&v));
+                            tools.push(AvailableTool::GraphQLQuery {
+                                endpoint: endpoint.to_string(),
+                                query: query.to_string(),
+                                variables,
+                                auth,
+                            });
+                        }
+                    }
+                }
+                "SqlQuery" => {
+                    if let (Some(conn), Some(query)) = (
+                        tool_req
+                            .parameters
+                            .get("connection_string")
+                            .and_then(|v| v.as_str()),
+                        tool_req.parameters.get("query").and_then(|v| v.as_str()),
+                    ) {
+                        let db_type = tool_req
+                            .parameters
+                            .get("database_type")
+                            .and_then(|v| v.as_str())
+                            .and_then(Self::parse_database_type)
+                            .unwrap_or(DatabaseType::SQLite);
+                        tools.push(AvailableTool::SqlQuery {
+                            connection_string: conn.to_string(),
+                            query: query.to_string(),
+                            database_type: db_type,
+                        });
+                    }
+                }
+                "SqliteQuery" => {
+                    if let (Some(path), Some(query)) = (
+                        tool_req
+                            .parameters
+                            .get("database_path")
+                            .and_then(|v| v.as_str()),
+                        tool_req.parameters.get("query").and_then(|v| v.as_str()),
+                    ) {
+                        tools.push(AvailableTool::SqliteQuery {
+                            database_path: path.to_string(),
+                            query: query.to_string(),
+                        });
+                    }
+                }
+                "CargoOperation" => {
+                    if let Some(op) = tool_req
+                        .parameters
+                        .get("operation")
+                        .and_then(|v| v.as_str())
+                    {
+                        let operation = Self::parse_cargo_operation(op);
+                        let package = tool_req
+                            .parameters
+                            .get("package")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string());
+                        let features = tool_req
+                            .parameters
+                            .get("features")
+                            .and_then(|v| v.as_array())
+                            .map(|arr| {
+                                arr.iter()
+                                    .filter_map(|v| v.as_str())
+                                    .map(|s| s.to_string())
+                                    .collect()
+                            });
+                        tools.push(AvailableTool::CargoOperation {
+                            operation,
+                            package,
+                            features,
+                        });
+                    }
+                }
+                "NpmOperation" => {
+                    if let Some(op) = tool_req
+                        .parameters
+                        .get("operation")
+                        .and_then(|v| v.as_str())
+                    {
+                        let operation = if let Some(map) = tool_req.parameters.as_object() {
+                            Self::parse_npm_operation(op, map)
+                        } else {
+                            Self::parse_npm_operation(op, &serde_json::Map::new())
+                        };
+                        let package = tool_req
+                            .parameters
+                            .get("package")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string());
+                        let dev = tool_req
+                            .parameters
+                            .get("dev")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false);
+                        tools.push(AvailableTool::NpmOperation {
+                            operation,
+                            package,
+                            dev,
+                        });
+                    }
+                }
+                "PipOperation" => {
+                    if let Some(op) = tool_req
+                        .parameters
+                        .get("operation")
+                        .and_then(|v| v.as_str())
+                    {
+                        let operation = Self::parse_pip_operation(op);
+                        let package = tool_req
+                            .parameters
+                            .get("package")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string());
+                        let requirements_file = tool_req
+                            .parameters
+                            .get("requirements_file")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string());
+                        tools.push(AvailableTool::PipOperation {
+                            operation,
+                            package,
+                            requirements_file,
+                        });
+                    }
+                }
+                "NetworkInfo" => {
+                    tools.push(AvailableTool::NetworkInfo);
+                }
+                "DockerList" => {
+                    if let Some(res) = tool_req
+                        .parameters
+                        .get("resource_type")
+                        .and_then(|v| v.as_str())
+                    {
+                        let resource_type = Self::parse_docker_resource(res);
+                        tools.push(AvailableTool::DockerList { resource_type });
+                    }
+                }
+                "DockerRun" => {
+                    if let Some(image) = tool_req.parameters.get("image").and_then(|v| v.as_str()) {
+                        let command = tool_req
+                            .parameters
+                            .get("command")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string());
+                        let ports = tool_req
+                            .parameters
+                            .get("ports")
+                            .and_then(|v| v.as_array())
+                            .map(|arr| {
+                                arr.iter()
+                                    .filter_map(|v| v.as_str())
+                                    .map(|s| s.to_string())
+                                    .collect()
+                            });
+                        let volumes = tool_req
+                            .parameters
+                            .get("volumes")
+                            .and_then(|v| v.as_array())
+                            .map(|arr| {
+                                arr.iter()
+                                    .filter_map(|v| v.as_str())
+                                    .map(|s| s.to_string())
+                                    .collect()
+                            });
+                        let environment = tool_req
+                            .parameters
+                            .get("environment")
+                            .and_then(|v| v.as_object())
+                            .map(|obj| {
+                                obj.iter()
+                                    .filter_map(|(k, v)| {
+                                        v.as_str().map(|s| (k.clone(), s.to_string()))
+                                    })
+                                    .collect()
+                            });
+                        tools.push(AvailableTool::DockerRun {
+                            image: image.to_string(),
+                            command,
+                            ports,
+                            volumes,
+                            environment,
+                        });
+                    }
+                }
+                "DockerStop" => {
+                    if let Some(container) = tool_req
+                        .parameters
+                        .get("container")
+                        .and_then(|v| v.as_str())
+                    {
+                        tools.push(AvailableTool::DockerStop {
+                            container: container.to_string(),
+                        });
+                    }
+                }
+                "DockerLogs" => {
+                    if let Some(container) = tool_req
+                        .parameters
+                        .get("container")
+                        .and_then(|v| v.as_str())
+                    {
+                        let follow = tool_req
+                            .parameters
+                            .get("follow")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false);
+                        let tail = tool_req
+                            .parameters
+                            .get("tail")
+                            .and_then(|v| v.as_u64())
+                            .map(|n| n as u32);
+                        tools.push(AvailableTool::DockerLogs {
+                            container: container.to_string(),
+                            follow,
+                            tail,
+                        });
+                    }
+                }
+                "JsonFormat" => {
+                    if let Some(input) = tool_req.parameters.get("input").and_then(|v| v.as_str()) {
+                        tools.push(AvailableTool::JsonFormat {
+                            input: input.to_string(),
+                        });
+                    }
+                }
+                "JsonQuery" => {
+                    if let (Some(input), Some(query)) = (
+                        tool_req.parameters.get("input").and_then(|v| v.as_str()),
+                        tool_req.parameters.get("query").and_then(|v| v.as_str()),
+                    ) {
+                        tools.push(AvailableTool::JsonQuery {
+                            input: input.to_string(),
+                            query: query.to_string(),
+                        });
+                    }
+                }
+                "CsvParse" => {
+                    if let Some(input) = tool_req.parameters.get("input").and_then(|v| v.as_str()) {
+                        let delimiter = tool_req
+                            .parameters
+                            .get("delimiter")
+                            .and_then(|v| v.as_str())
+                            .and_then(|s| s.chars().next());
+                        tools.push(AvailableTool::CsvParse {
+                            input: input.to_string(),
+                            delimiter,
+                        });
+                    }
+                }
+                "RegexMatch" => {
+                    if let (Some(pattern), Some(text)) = (
+                        tool_req.parameters.get("pattern").and_then(|v| v.as_str()),
+                        tool_req.parameters.get("text").and_then(|v| v.as_str()),
+                    ) {
+                        let flags = tool_req
+                            .parameters
+                            .get("flags")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string());
+                        tools.push(AvailableTool::RegexMatch {
+                            pattern: pattern.to_string(),
+                            text: text.to_string(),
+                            flags,
+                        });
+                    }
+                }
+                "TextTransform" => {
+                    if let (Some(input), Some(op)) = (
+                        tool_req.parameters.get("input").and_then(|v| v.as_str()),
+                        tool_req
+                            .parameters
+                            .get("operation")
+                            .and_then(|v| v.as_str()),
+                    ) {
+                        let operation = if let Some(map) = tool_req.parameters.as_object() {
+                            Self::parse_text_operation(op, map)
+                        } else {
+                            Self::parse_text_operation(op, &serde_json::Map::new())
+                        };
+                        tools.push(AvailableTool::TextTransform {
+                            input: input.to_string(),
+                            operation,
+                        });
+                    }
+                }
+                "SetConfig" => {
+                    if let (Some(key), Some(value)) = (
+                        tool_req.parameters.get("key").and_then(|v| v.as_str()),
+                        tool_req.parameters.get("value"),
+                    ) {
+                        tools.push(AvailableTool::SetConfig {
+                            key: key.to_string(),
+                            value: value.clone(),
+                        });
+                    }
+                }
+                "GetConfig" => {
+                    let key = tool_req
+                        .parameters
+                        .get("key")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    tools.push(AvailableTool::GetConfig { key });
+                }
+                "ExportConversation" => {
+                    if let (Some(format_str), Some(path)) = (
+                        tool_req.parameters.get("format").and_then(|v| v.as_str()),
+                        tool_req.parameters.get("path").and_then(|v| v.as_str()),
+                    ) {
+                        let format = Self::parse_export_format(format_str);
+                        tools.push(AvailableTool::ExportConversation {
+                            format,
+                            path: path.to_string(),
+                        });
+                    }
+                }
+                "ImportConversation" => {
+                    if let Some(path) = tool_req.parameters.get("path").and_then(|v| v.as_str()) {
+                        tools.push(AvailableTool::ImportConversation {
+                            path: path.to_string(),
+                        });
+                    }
+                }
+                "ClearHistory" => {
+                    tools.push(AvailableTool::ClearHistory);
+                }
+                "ScheduleTask" => {
+                    if let (Some(command), Some(schedule)) = (
+                        tool_req.parameters.get("command").and_then(|v| v.as_str()),
+                        tool_req.parameters.get("schedule").and_then(|v| v.as_str()),
+                    ) {
+                        let name = tool_req
+                            .parameters
+                            .get("name")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string());
+                        tools.push(AvailableTool::ScheduleTask {
+                            command: command.to_string(),
+                            schedule: schedule.to_string(),
+                            name,
+                        });
+                    }
+                }
+                "ListScheduledTasks" => {
+                    tools.push(AvailableTool::ListScheduledTasks);
+                }
+                "CancelScheduledTask" => {
+                    if let Some(name) = tool_req.parameters.get("name").and_then(|v| v.as_str()) {
+                        tools.push(AvailableTool::CancelScheduledTask {
+                            name: name.to_string(),
                         });
                     }
                 }
@@ -537,6 +1298,177 @@ Analyze the request and respond with JSON only:"#,
         }
 
         tools
+    }
+
+    fn parse_edit_operation(value: &serde_json::Value) -> Option<EditOperation> {
+        let obj = value.as_object()?;
+        let op = obj.get("type")?.as_str()?.to_lowercase();
+        match op.as_str() {
+            "replace" => Some(EditOperation::Replace {
+                old: obj.get("old")?.as_str()?.to_string(),
+                new: obj.get("new")?.as_str()?.to_string(),
+            }),
+            "insert" => Some(EditOperation::Insert {
+                line: obj.get("line")?.as_u64()? as usize,
+                content: obj.get("content")?.as_str()?.to_string(),
+            }),
+            "append" => Some(EditOperation::Append {
+                content: obj.get("content")?.as_str()?.to_string(),
+            }),
+            "delete" => Some(EditOperation::Delete {
+                line_start: obj.get("line_start")?.as_u64()? as usize,
+                line_end: obj
+                    .get("line_end")
+                    .and_then(|v| v.as_u64())
+                    .map(|n| n as usize),
+            }),
+            _ => None,
+        }
+    }
+
+    fn parse_api_auth(value: &serde_json::Value) -> Option<ApiAuth> {
+        let obj = value.as_object()?;
+        let kind = obj.get("type")?.as_str()?.to_lowercase();
+        match kind.as_str() {
+            "bearer" => obj
+                .get("token")
+                .and_then(|v| v.as_str())
+                .map(|t| ApiAuth::Bearer {
+                    token: t.to_string(),
+                }),
+            "basic" => Some(ApiAuth::Basic {
+                username: obj.get("username")?.as_str()?.to_string(),
+                password: obj.get("password")?.as_str()?.to_string(),
+            }),
+            "apikey" => Some(ApiAuth::ApiKey {
+                key: obj.get("key")?.as_str()?.to_string(),
+                header: obj.get("header")?.as_str()?.to_string(),
+            }),
+            _ => None,
+        }
+    }
+
+    fn parse_database_type(s: &str) -> Option<DatabaseType> {
+        match s.to_lowercase().as_str() {
+            "postgres" | "postgresql" => Some(DatabaseType::PostgreSQL),
+            "mysql" => Some(DatabaseType::MySQL),
+            "sqlite" => Some(DatabaseType::SQLite),
+            "mongodb" => Some(DatabaseType::MongoDB),
+            _ => None,
+        }
+    }
+
+    fn parse_cargo_operation(s: &str) -> CargoOperation {
+        match s.to_lowercase().as_str() {
+            "build" => CargoOperation::Build,
+            "run" => CargoOperation::Run,
+            "test" => CargoOperation::Test,
+            "check" => CargoOperation::Check,
+            "install" => CargoOperation::Install,
+            "add" => CargoOperation::Add,
+            "remove" => CargoOperation::Remove,
+            "update" => CargoOperation::Update,
+            "clean" => CargoOperation::Clean,
+            _ => CargoOperation::Build,
+        }
+    }
+
+    fn parse_npm_operation(
+        op: &str,
+        params: &serde_json::Map<String, serde_json::Value>,
+    ) -> NpmOperation {
+        match op.to_lowercase().as_str() {
+            "install" => NpmOperation::Install,
+            "uninstall" => NpmOperation::Uninstall,
+            "update" => NpmOperation::Update,
+            "audit" => NpmOperation::Audit,
+            "run" => {
+                let script = params
+                    .get("script")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                NpmOperation::Run { script }
+            }
+            "list" => NpmOperation::List,
+            _ => NpmOperation::List,
+        }
+    }
+
+    fn parse_pip_operation(op: &str) -> PipOperation {
+        match op.to_lowercase().as_str() {
+            "install" => PipOperation::Install,
+            "uninstall" => PipOperation::Uninstall,
+            "list" => PipOperation::List,
+            "freeze" => PipOperation::Freeze,
+            "show" => PipOperation::Show,
+            _ => PipOperation::List,
+        }
+    }
+
+    fn parse_docker_resource(s: &str) -> DockerResourceType {
+        match s.to_lowercase().as_str() {
+            "containers" => DockerResourceType::Containers,
+            "images" => DockerResourceType::Images,
+            "volumes" => DockerResourceType::Volumes,
+            "networks" => DockerResourceType::Networks,
+            _ => DockerResourceType::Containers,
+        }
+    }
+
+    fn parse_text_operation(
+        op: &str,
+        params: &serde_json::Map<String, serde_json::Value>,
+    ) -> TextOperation {
+        match op.to_lowercase().as_str() {
+            "upper" | "uppercase" => TextOperation::ToUpperCase,
+            "lower" | "lowercase" => TextOperation::ToLowerCase,
+            "trim" => TextOperation::Trim,
+            "count" => TextOperation::Count {
+                pattern: params
+                    .get("pattern")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            },
+            "replace" => TextOperation::Replace {
+                old: params
+                    .get("old")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                new: params
+                    .get("new")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            },
+            "split" => TextOperation::Split {
+                delimiter: params
+                    .get("delimiter")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            },
+            "join" => TextOperation::Join {
+                delimiter: params
+                    .get("delimiter")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            },
+            _ => TextOperation::Trim,
+        }
+    }
+
+    fn parse_export_format(s: &str) -> ExportFormat {
+        match s.to_lowercase().as_str() {
+            "json" => ExportFormat::Json,
+            "markdown" | "md" => ExportFormat::Markdown,
+            "text" | "txt" => ExportFormat::Text,
+            "html" => ExportFormat::Html,
+            _ => ExportFormat::Json,
+        }
     }
 
     fn enhanced_fallback_parse(&self, _input: &str) -> Vec<AvailableTool> {


### PR DESCRIPTION
## Summary
- extend analysis prompt with additional tools
- implement parsing for many tool variants
- add helper functions for parsing parameters

## Testing
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687789d1650c8326896aa19ceb506920